### PR TITLE
fix numeric version warning ( RT#65284 )

### DIFF
--- a/lib/Devel/TraceUse.pm
+++ b/lib/Devel/TraceUse.pm
@@ -118,7 +118,7 @@ sub show_trace
 		my $caller = $mod->{caller};
 		my $message = sprintf( '%4s.', $mod->{rank} ) . '  ' x $pos;
 		$message .= "$mod->{module}";
-		my $version = $mod->{module}->VERSION;
+		my $version = ${"$mod->{module}::VERSION"};
 		$message .= defined $version ? " $version," : ',';
 		$message .= " $caller->{filename}"
 			if defined $caller->{filename};


### PR DESCRIPTION
This fixes https://rt.cpan.org/Public/Bug/Display.html?id=65284

I tested it on my box and it passed tests + shut up the warnings when trying to trace a huge module tree ( Dist::Zilla, around 557 modules - excluding core! )
