### PR TITLE
Add support for "perl -c"

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Devel-TraceUse
 
+2.10
+    - Added support for "perl -c": dump tree at CHECK phase if -c is set
+      (contributed by Olivier Mengué (DOLMEN))
+
 2.06 Sun Jan 15 00:44:13 CET 2012
     No code change, but:
     - More thoroughly remove @INC from the error output

--- a/lib/Devel/TraceUse.pm
+++ b/lib/Devel/TraceUse.pm
@@ -168,7 +168,7 @@ sub numify {
 	return 0+ ((shift @parts).'.'.join('', map { (length) < 3 ? (sprintf "%03d", $_) : $_ } @parts));
 }
 
-END
+sub dump_result
 {
 	return if $quiet;
 
@@ -219,6 +219,15 @@ END
 	close $output_fh if defined $output_fh;
 }
 
+# Install the final hook
+# If perl runs with -c we want to dump 
+CHECK {
+    # "perl -c" ?
+    dump_result() if $^C;
+}
+
+END { dump_result() }
+
 1;
 __END__
 
@@ -266,6 +275,11 @@ a loaded module to the tree, it will be reported at the end.
 Even though using C<-MDevel::TraceUse> is possible, it is preferable to
 use C<-d:TraceUse>, as the debugger will provide more accurate information.
 You will be reminded in the output.
+
+If you want to know only the modules loaded during the compile phase, use
+the standard C<-c> option of perl (see L<perlrun>):
+
+  $ perl -c -d:TraceUse your_program.pl
 
 =head2 Parameters
 
@@ -318,7 +332,9 @@ Philippe Bruhat, C<< <book at cpan.org> >>
 
 C<hidecore> option contributed by David Leadbeater, C<< <dgl@dgl.cx> >>.
 
-C<output> option contributed by Olivier MenguE<eacute>, C<< <dolmen@cpan.org> >>.
+C<output> option contributed by Olivier MenguE<eacute> (L<DOLMEN|mailto:dolmen@cpan.org>).
+
+C<perl -c> support contributed by Olivier MenguE<eacute> (L<DOLMEN|mailto:dolmen@cpan.org>).
 
 =head1 BUGS
 


### PR DESCRIPTION
If perl runs with "-c", the use tree will now be dumped at CHECK time (instead of never).
